### PR TITLE
fix: correctly removing user/configuration when removing/purging package

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -9,9 +9,19 @@ EXTPLORER_POOL_CONF="/etc/php5/fpm/pool.d/openmediavault-extplorer-site.conf"
 EXTPLORER_SITE_CONF="/etc/nginx/openmediavault-webgui.d/openmediavault-extplorer-site.conf"
 
 case "$1" in
-    purge|remove)
+    remove)
+        service php5-fpm stop
+        service nginx stop
+
         rm -rf /usr/share/extplorer
 
+        userdel -r extplorer
+
+        service php5-fpm start
+        service nginx start
+   ;;
+
+   purge)
         if [ -e "${EXTPLORER_SITE_CONF}" ]; then
             rm ${EXTPLORER_SITE_CONF}
         fi
@@ -19,11 +29,6 @@ case "$1" in
         if [ -e "${EXTPLORER_POOL_CONF}" ]; then
             rm ${EXTPLORER_POOL_CONF}
         fi
-
-        userdel -r extplorer
-
-        service php5-fpm reload
-        service nginx reload
     ;;
 
     upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,8 @@ install:
 	chmod +x $(CURDIR)/debian/openmediavault-${PLUGIN_NAME}/usr/share/openmediavault/mkconf/nginx.d/90-${PLUGIN_NAME}
 	chmod +x $(CURDIR)/debian/openmediavault-${PLUGIN_NAME}/usr/share/openmediavault/mkconf/php5fpm.d/90-${PLUGIN_NAME}
 
+build: install
+
 binary-indep: install omv_clean_scm
 	dh_testdir
 	dh_testroot


### PR DESCRIPTION
The attached commit fixes two problems in removing and purging the Debian package.
1) The user extplorer could not be removed due to the usage by the php5-fpm service.
2) When purging the package the script and therefore the removal of the user and the configuration is done twice, resulting in error messages (user does not exist) and leaving the package unpurged.

The default target for building the Debian package was not given previously. It was set to install.
